### PR TITLE
Improve error message when since or until args missing.

### DIFF
--- a/git_guilt/guilt.py
+++ b/git_guilt/guilt.py
@@ -642,7 +642,7 @@ class PyGuilt(object):
     def process_args(self):
         self.args = self.parser.parse_args()
         if not (self.args.since and self.args.until):
-            raise GitError('Invalid arguments')
+            raise GitError(self.parser.format_usage())
 
     def populate_trees(self):
         '''

--- a/test/test_guilt.py
+++ b/test/test_guilt.py
@@ -1,21 +1,21 @@
 # -*- coding: UTF-8 -*-
 # Copyright (c) 2015, Matt Boyer
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 #     1. Redistributions of source code must retain the above copyright notice,
 #     this list of conditions and the following disclaimer.
-# 
+#
 #     2. Redistributions in binary form must reproduce the above copyright
 #     notice, this list of conditions and the following disclaimer in the
 #     documentation and/or other materials provided with the distribution.
-# 
+#
 #     3. Neither the name of the copyright holder nor the names of its
 #     contributors may be used to endorse or promote products derived from this
 #     software without specific prior written permission.
-# 
+#
 #     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
 #     IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
 #     THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
@@ -220,7 +220,9 @@ class ArgTestCase(TestCase):
         self.assertRaises(guilt_module.GitError, self.guilt.process_args)
 
         self.assertEquals(1, self.guilt.run())
-        self.assertEquals('Invalid arguments\n', mock_stderr.getvalue())
+        self.assertEquals(
+            self.guilt.parser.format_usage() + '\n',
+            mock_stderr.getvalue())
 
         stderr_patch.stop()
 


### PR DESCRIPTION
Show the user the `format_usage` string from `ArgumentParser`
instead of 'Invalid arguments'.

Also my editor stripped some trailing whitespace, let me know if you would rather this be left in and I can ammend the commit.