### PR TITLE
Adds sane defaults to git-guilt positional params

### DIFF
--- a/git_guilt/guilt.py
+++ b/git_guilt/guilt.py
@@ -823,11 +823,11 @@ Please note that git-guilt needs git >= 1.7.2 in order to process binary files.
         'authors\' email addresses instead of their names',
     )
 
-    # TODO Surely there can be sensible defaults for the since and until revs
     parser.add_argument(
         'since',
         metavar='since',
         nargs='?',
+        default='HEAD~1',
         help='The revision starting from which the transfer of blame should '
         'be reported',
     )
@@ -835,6 +835,7 @@ Please note that git-guilt needs git >= 1.7.2 in order to process binary files.
         'until',
         metavar='until',
         nargs='?',
+        default='HEAD',
         help='The revision until which the transfer of blame should be '
         'reported',
     )


### PR DESCRIPTION
My common use case is adding `git-guilt` to my post-commit hook, being invoked as follows:

```
if git rev-parse --quiet --verify HEAD~1 && command -v git-guilt 1>/dev/null 2>/dev/null; then
  git guilt HEAD~1
fi
```

Without this PR, it seems this isn't a full port of the JavaScript version of `git-guilt` after all.